### PR TITLE
Parse express request size to integer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signalfx-collect",
-  "version": "2.0.0-beta1",
+  "version": "2.0.0-beta2",
   "description": "SignalFx library to collect nodejs metrics and report to SignalFx",
   "main": "src/index.js",
   "scripts": {

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -15,7 +15,7 @@ module.exports = {
           route: req.route ? req.route.path : null,
           method: getExpressRequestMethod(req.route),
           time: Date.now() - requestStart,
-          size: req.get('content-length'),
+          size: parseInt(req.get('content-length')),
           timestamp: requestStart
         };
 


### PR DESCRIPTION
Fix issue where the express middleware is reporting `rq_size` metric as string by parsing it to integer before sending.