### PR TITLE
Add Splunk notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+>ℹ️&nbsp;&nbsp;SignalFx was acquired by Splunk in October 2019. See [Splunk SignalFx](https://www.splunk.com/en_us/investor-relations/acquisitions/signalfx.html) for more information.
+
 <p align="center">
   <a href="https://github.com/signalfx/signalfx-nodejs-collect/releases">
     <img alt="GitHub release (latest by date)" src="https://img.shields.io/github/v/release/signalfx/signalfx-nodejs-collect?include_prereleases&logo=github&style=for-the-badge&cacheSeconds=3600">


### PR DESCRIPTION
This small PR adds the acquisition notice with a link to the README file.